### PR TITLE
chore: add google analytics integration

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -11,7 +11,7 @@ defaultContentLanguage = "en-gb"
 
 # To enable Google Analytics 4 (gtag.js) provide G-MEASUREMENT_ID below.
 # To disable Google Analytics, simply leave the field empty or remove the next line
-googleAnalytics = '' # G-MEASUREMENT_ID
+googleAnalytics = 'G-VLRPXBX5JL' # G-MEASUREMENT_ID
 
 # Enable emojis globally
 enableEmoji = true


### PR DESCRIPTION
Adds the provided Google Analytics Measurement ID to `hugo.toml` to enable site traffic monitoring.

---
*PR created automatically by Jules for task [9324517421441201659](https://jules.google.com/task/9324517421441201659) started by @abinmn*